### PR TITLE
fix: remove minio credential-injection

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeflowv1 "github.com/StatCan/kubeflow-controller/pkg/apis/kubeflowcontroller/v1"
 	kubeflowv1alpha1 "github.com/StatCan/kubeflow-controller/pkg/apis/kubeflowcontroller/v1alpha1"
 )
@@ -27,55 +26,4 @@ func RegisterPodDefault(name string, callback NewPodDefaultFunc) error {
 	return nil
 }
 
-func init() {
-	RegisterPodDefault("minio-profile", func(profile *kubeflowv1.Profile) *kubeflowv1alpha1.PodDefault {
-		roleName := cleanName(fmt.Sprintf("profile-%s", profile.Name))
-
-		return &kubeflowv1alpha1.PodDefault{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "minio-profile",
-				Namespace: profile.Name,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
-				},
-			},
-			Spec: kubeflowv1alpha1.PodDefaultSpec{
-				Desc: "Inject credentials to access MinIO object storage",
-				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"minio-profile": "true",
-					},
-				},
-				Annotations: map[string]string{
-					"vault.hashicorp.com/agent-inject":                              "true",
-					"vault.hashicorp.com/agent-pre-populate":                        "false",
-					"vault.hashicorp.com/role":                                      roleName,
-					"vault.hashicorp.com/agent-inject-secret-minio-minimal-tenant1": "minio_minimal_tenant1/keys/" + roleName,
-					"vault.hashicorp.com/agent-inject-template-minio-minimal-tenant1": fmt.Sprintf(`
-{{- with secret "minio_minimal_tenant1/keys/%s" }}
-export MINIO_URL="http://minimal-tenant1-minio.minio:9000"
-export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
-export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
-{{- end }}
-					`, roleName),
-					"vault.hashicorp.com/agent-inject-secret-minio-pachyderm-tenant1": "minio_pachyderm_tenant1/keys/" + roleName,
-					"vault.hashicorp.com/agent-inject-template-minio-pachyderm-tenant1": fmt.Sprintf(`
-{{- with secret "minio_pachyderm_tenant1/keys/%s" }}
-export MINIO_URL="http://pachyderm-tenant1-minio.minio:9000"
-export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
-export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
-{{- end }}
-					`, roleName),
-					"vault.hashicorp.com/agent-inject-secret-minio-premium-tenant1": "minio_premium_tenant1/keys/" + roleName,
-					"vault.hashicorp.com/agent-inject-template-minio-premium-tenant1": fmt.Sprintf(`
-{{- with secret "minio_premium_tenant1/keys/%s" }}
-export MINIO_URL="http://premium-tenant1-minio.minio:9000"
-export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
-export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
-{{- end }}
-					`, roleName),
-				},
-			},
-		}
-	})
-}
+func init() {}


### PR DESCRIPTION
fixes https://github.com/StatCan/daaas/issues/196

To test :
- Need to install MiniKF
- Download the config file
- Changes in Controller.go : Comment out the following lines:
> 502 	`err = c.doPachydermRoleBinding(profile)`
> 509	`err = c.doSeldonRoleBinding(profile)`
> 533 	`err = c.vaultConfigurer.ConfigVaultForProfile(profile.Name, profile.Spec.Owner.Name, users)`
- Create a local deployment yaml with only bare minimum.
- run :
`go run . -kubeconfig=$HOME/.kube/[minikfconfig] -master [url for minikf]`
or
```
go build -o kubeflow-controller .
./kubeflow-controller -kubeconfig=$HOME/.kube/[minikfconfig] -master [url for minikf]
```